### PR TITLE
AutoAbstol must use init_curmax as initial value

### DIFF
--- a/src/DiffEqCallbacks.jl
+++ b/src/DiffEqCallbacks.jl
@@ -13,7 +13,7 @@ module DiffEqCallbacks
   end
 
   function AutoAbstol(save=true;init_curmax=1e-6)
-    affect! = AutoAbstolAffect(1e-6)
+    affect! = AutoAbstolAffect(init_curmax)
     condtion = true
     interp_points = 0
     rootfind = false


### PR DESCRIPTION
The function `AutoAbstol` that creates the callback to manage
automatic absolute tolerance was using a hard coded value `1e-6`
instead of the value passed in the parameter `init_curmax`.