### PR TITLE
Allow element-wise automatic absolute tolerances

### DIFF
--- a/src/autoabstol.jl
+++ b/src/autoabstol.jl
@@ -3,8 +3,18 @@ type AutoAbstolAffect{T}
 end
 # Now make `affect!` for this:
 function (p::AutoAbstolAffect)(integrator)
-  p.curmax = max(p.curmax,integrator.u)
-  integrator.opts.abstol = p.curmax * integrator.opts.reltol
+  if typeof(p.curmax) <: AbstractArray
+    p.curmax .= max.(p.curmax,integrator.u)
+  else
+    p.curmax = max(p.curmax,maximum(integrator.u))
+  end
+
+  if typeof(integrator.opts.abstol) <: AbstractArray
+    integrator.opts.abstol .= p.curmax .* integrator.opts.reltol
+  else
+    integrator.opts.abstol = p.curmax .* integrator.opts.reltol
+  end
+  
   u_modified!(integrator,false)
 end
 

--- a/test/autoabstol_tests.jl
+++ b/test/autoabstol_tests.jl
@@ -12,3 +12,20 @@ at3 = integrator.opts.abstol
 @test at2 < at3
 
 solve(prob,BS3(),callback=cb)
+
+prob2D = prob_ode_2Dlinear
+cb2D = AutoAbstol(init_curmax=zeros(2))
+integrator2D_1 = init(prob,BS3(),callback=cb,abstol=1e-6)
+integrator2D_2 = init(prob,BS3(),callback=cb,abstol=[1e-6,1e-6])
+@test all(integrator2D_2.opts.abstol .== integrator2D_1.opts.abstol)
+step!(integrator2D_1)
+step!(integrator2D_2)
+@test all(integrator2D_2.opts.abstol .== integrator2D_1.opts.abstol)
+step!(integrator2D_1)
+step!(integrator2D_2)
+@test all(integrator2D_2.opts.abstol .== integrator2D_1.opts.abstol)
+
+sol1 = solve(prob,BS3(),callback=cb2D,abstol=[1e-6,1e-6])
+sol2 = solve(prob,BS3(),callback=cb2D,abstol=[1e-6,1e-6],reltol=[1e-3,1e-3])
+@test sol1.t == sol2.t && sol1.u == sol2.u
+@test_throws MethodError solve(prob,BS3(),callback=cb2D,abstol=1e-6)


### PR DESCRIPTION
Hi!

I thought the calculation of element-wise automatic absolute tolerances might be useful in the case of multiple variables with different scales.

This is a first proposed change to the current `AutoAbstol` callback which implements that feature. However, I'm not sure whether it is better to check if both `p.curmax` and `integrator.opts.abstol` are of type `AbstractArray` (as it is done currently), or to check if they are of type `Number` and use broadcasting in all other cases. Or if there is even an easier way which get's rid of the type tests ;)