### PR TITLE
Always take absolute values

### DIFF
--- a/src/autoabstol.jl
+++ b/src/autoabstol.jl
@@ -4,9 +4,9 @@ end
 # Now make `affect!` for this:
 function (p::AutoAbstolAffect)(integrator)
   if typeof(p.curmax) <: AbstractArray
-    p.curmax .= max.(p.curmax,integrator.u)
+    @. p.curmax = max(p.curmax,abs(integrator.u))
   else
-    p.curmax = max(p.curmax,maximum(integrator.u))
+    p.curmax = max(p.curmax,maximum(abs.(integrator.u)))
   end
 
   if typeof(integrator.opts.abstol) <: AbstractArray
@@ -14,7 +14,7 @@ function (p::AutoAbstolAffect)(integrator)
   else
     integrator.opts.abstol = p.curmax .* integrator.opts.reltol
   end
-  
+
   u_modified!(integrator,false)
 end
 
@@ -25,7 +25,7 @@ function AutoAbstol_initialize(cb,t,u,integrator)
 end
 
 function AutoAbstol(save=true;init_curmax=0.0)
-  affect! = AutoAbstolAffect(init_curmax)
+  affect! = AutoAbstolAffect(abs.(init_curmax))
   condtion = (t,u,integrator) -> true
   save_positions = (save,false)
   DiscreteCallback(condtion,affect!;


### PR DESCRIPTION
One should always take the maximum of absolute values, otherwise negative entries in `u` do not have any influence on the absolute tolerance. Maybe OrdinaryDiffEq should also enforce positive values of `abstol` and `reltol`?