### PR TITLE
Updates for NLsolve PR

### DIFF
--- a/src/manifold.jl
+++ b/src/manifold.jl
@@ -11,7 +11,6 @@ Base.@pure function determine_chunksize(u,CS)
 end
 
 function autodiff_setup(f!, initial_x, chunk_size::Type{Val{CS}}) where CS
-
     fvec! = NLsolve.reshape_f(f!, initial_x)
     permf! = (fx::AbstractVector, x::AbstractVector) -> fvec!(x, fx)
 
@@ -31,8 +30,6 @@ function autodiff_setup(f!, initial_x, chunk_size::Type{Val{CS}}) where CS
     return DifferentiableMultivariateFunction(fvec!, g!, fg!)
 end
 
-non_autodiff_setup(f!, initial_x) = DifferentiableMultivariateFunction(f!, initial_x)
-
 struct NLSOLVEJL_SETUP{CS,AD} end
 Base.@pure NLSOLVEJL_SETUP(;chunk_size=0,autodiff=true) = NLSOLVEJL_SETUP{chunk_size,autodiff}()
 (p::NLSOLVEJL_SETUP)(f, u0; kwargs...) = (res=NLsolve.nlsolve(f, u0; kwargs...); res.zero)
@@ -40,7 +37,7 @@ function (p::NLSOLVEJL_SETUP{CS,AD})(::Type{Val{:init}},f,u0_prototype) where {C
   if AD
     return autodiff_setup(f, u0_prototype, Val{determine_chunksize(u0_prototype, CS)})
   else
-    return non_autodiff_setup(f, u0_prototype)
+    return DifferentiableMultivariateFunction(f!, initial_x)
   end
 end
 

--- a/test/manifold_tests.jl
+++ b/test/manifold_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, Base.Test, DiffEqBase, DiffEqCallbacks
+using DiffEqCallbacks, OrdinaryDiffEq, RecursiveArrayTools, Base.Test
 
 u0 = ones(2,2)
 f = function (t,u,du)
@@ -32,3 +32,11 @@ cb_t = ManifoldProjection(g_t)
 solve(prob,Vern7(),callback=cb_t)
 @time sol_t = solve(prob,Vern7(),callback=cb_t)
 @test sol_t.u == sol.u && sol_t.t == sol.t
+
+# test array partitions
+
+u₀ = ArrayPartition(ones(2), ones(2))
+prob = ODEProblem(f, u₀, (0.0, 100.0))
+
+sol = solve(prob,Vern7(),callback=cb)
+@test sol[end][1]^2 + sol[end][2]^2 ≈ 2


### PR DESCRIPTION
This is not ready to merge yet since it depends on https://github.com/JuliaNLSolvers/NLsolve.jl/pull/117 and https://github.com/JuliaNLSolvers/NLSolversBase.jl/pull/18. If chunk size would be determined by `NLsolve` (or could be specified) we could even get rid of `autodiff_setup`. 

It just shows that `ManifoldProjection` works with `ArrayPartition`.