### PR TITLE
Add PeriodicCallback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,22 @@ SavingCallback(save_func, saved_values::SavedValues;
                tdir=1)
 ```
 - `save_func(t, u, integrator)` returns the quantities which shall be saved.
-- `saved_values::SavedValues` contains vectors `t::Vector{tType}`, 
-  `saveval::Vector{savevalType}` of the saved quantities. Here, 
+- `saved_values::SavedValues` contains vectors `t::Vector{tType}`,
+  `saveval::Vector{savevalType}` of the saved quantities. Here,
   `save_func(t, u, integrator)::savevalType`.
 - `saveat` Mimicks `saveat` in `solve` for ODEs.
 - `save_everystep` Mimicks `save_everystep` in `solve` for ODEs.
 - `tdir` should be `sign(tspan[end]-tspan[1])`. It defaults to `1` and should
   be adapted if `tspan[1] > tspan[end]`.
+
+## PeriodicCallback
+
+`PeriodicCallback` can be used when a function should be called periodically in terms of integration time (as opposed to wall time), i.e. at `t = tspan[1]`, `t = tspan[1] + Δt`, `t = tspan[1] + 2Δt`, and so on. This callback can, for example, be used to model a digital controller for an analog system, running at a fixed rate.
+
+A `PeriodicCallback` can be constructed as follows:
+
+```julia
+PeriodicCallback(f, Δt::Number; kwargs...)
+```
+
+where `f` is the function to be called periodically, `Δt` is the period, and `kwargs` are keyword arguments accepted by the `DiscreteCallback` constructor.

--- a/src/DiffEqCallbacks.jl
+++ b/src/DiffEqCallbacks.jl
@@ -12,5 +12,6 @@ module DiffEqCallbacks
   include("domain.jl")
   include("stepsizelimiters.jl")
   include("saving.jl")
+  include("periodic.jl")
 
 end # module

--- a/src/periodic.jl
+++ b/src/periodic.jl
@@ -1,6 +1,4 @@
 function PeriodicCallback(f, Δt::Number; initialize = DiffEqBase.INITIALIZE_DEFAULT, kwargs...)
-    @assert Δt > 0
-
     # Value of `t` at which `f` should be called next:
     tnext = Ref(typemax(Δt))
     condition = (t, u, integrator) -> t == tnext[]
@@ -13,7 +11,7 @@ function PeriodicCallback(f, Δt::Number; initialize = DiffEqBase.INITIALIZE_DEF
         tnew = tnext[] + Δt
         tstops = integrator.opts.tstops
         for i in length(tstops) : -1 : 1 # reverse iterate to encounter large elements earlier
-            if tstops.valtree[i] > tnew # TODO: relying on implementation detail
+            if DataStructures.compare(tstops.comparer, tnew, tstops.valtree[i]) # TODO: relying on implementation details
                 tnext[] = tnew
                 add_tstop!(integrator, tnew)
                 break
@@ -23,6 +21,7 @@ function PeriodicCallback(f, Δt::Number; initialize = DiffEqBase.INITIALIZE_DEF
 
     # Initialization: first call to `f` should be *before* any time steps have been taken:
     initialize_periodic = function (c, t, u, integrator)
+        @assert integrator.tdir == sign(Δt)
         initialize(c, t, u, integrator)
         tnext[] = t
         affect!(integrator)

--- a/src/periodic.jl
+++ b/src/periodic.jl
@@ -1,4 +1,4 @@
-function PeriodicCallback(f, Δt::Number; kwargs...)
+function PeriodicCallback(f, Δt::Number; initialize = DiffEqBase.INITIALIZE_DEFAULT, kwargs...)
     @assert Δt > 0
 
     # Value of `t` at which `f` should be called next:
@@ -22,12 +22,13 @@ function PeriodicCallback(f, Δt::Number; kwargs...)
     end
 
     # Initialization: first call to `f` should be *before* any time steps have been taken:
-    initialize = function (c, t, u, integrator)
+    initialize_periodic = function (c, t, u, integrator)
+        initialize(c, t, u, integrator)
         tnext[] = t
         affect!(integrator)
     end
 
-    DiscreteCallback(condition, affect!; initialize = initialize, kwargs...)
+    DiscreteCallback(condition, affect!; initialize = initialize_periodic, kwargs...)
 end
 
 export PeriodicCallback

--- a/src/periodic.jl
+++ b/src/periodic.jl
@@ -1,0 +1,29 @@
+function PeriodicCallback(f, Δt::Number; kwargs...)
+    @assert Δt > 0
+
+    # Value of `t` at which `f` should be called next:
+    t_next = Ref(typemax(Δt))
+    condition = (t, u, integrator) -> t == t_next[]
+
+    # Call f, update t_next, and make sure we stop at the new t_next
+    affect! = function (integrator)
+        f(integrator)
+
+        # Schedule next call to `f` using `add_tstops!`, but be careful not to keep integrating forever
+        t_new = t_next[] + Δt
+        if any(t -> t > t_new, integrator.opts.tstops.valtree) # TODO: accessing internal data...
+            t_next[] = t_new
+            add_tstop!(integrator, t_new)
+        end
+    end
+
+    # Initialization: first call to `f` should be *before* any time steps have been taken:
+    initialize = function (c, t, u, integrator)
+        t_next[] = t
+        affect!(integrator)
+    end
+
+    DiscreteCallback(condition, affect!; initialize = initialize, kwargs...)
+end
+
+export PeriodicCallback

--- a/test/periodic_tests.jl
+++ b/test/periodic_tests.jl
@@ -23,7 +23,9 @@ for tmax_problem in [tmax; Inf]
     # Callbacks periodically increase the input to the integrators:
     Δt1 = 0.5
     increase_du_1 = integrator -> du[1] += 1
-    periodic1 = PeriodicCallback(increase_du_1, Δt1)
+    periodic1_initialized = Ref(false)
+    initialize1 = (c, t, u, integrator) -> periodic1_initialized[] = true
+    periodic1 = PeriodicCallback(increase_du_1, Δt1; initialize = initialize1)
 
     Δt2 = 1.
     increase_du_2 = integrator -> du[2] += 1
@@ -34,6 +36,9 @@ for tmax_problem in [tmax; Inf]
 
     # Solve.
     sol = solve(prob, Tsit5(); callback = CallbackSet(terminator, periodic1, periodic2), tstops = [tmax])
+
+    # Ensure that initialize1 has been called
+    @test periodic1_initialized[]
 
     # Make sure we haven't integrated past tmax:
     @test sol.t[end] == tmax

--- a/test/periodic_tests.jl
+++ b/test/periodic_tests.jl
@@ -1,0 +1,52 @@
+using Base.Test, OrdinaryDiffEq, DiffEqCallbacks
+
+tmin = 0.1
+tmax = 5.2
+
+for tmax_problem in [tmax; Inf]
+    # Test with both a finite and an infinite tspan for the ODEProblem.
+    #
+    # Having support for infinite tspans is one of the main reasons for implementing PeriodicCallback
+    # using add_tstop!, instead of just passing in a linspace as the tstops solve argument.
+    # (the other being that the length of the internal tstops collection would otherwise become
+    # linear in the length of the integration time interval.
+    #
+    # Testing a finite tspan is necessary because a naive implementation could add tstops after
+    # tmax and thus integrate for too long (or even indefinitely).
+
+    # Dynamics: two independent single integrators:
+    du = [0; 0]
+    u0 = [0.; 0.]
+    dynamics = (t, u) -> eltype(u).(du)
+    prob = ODEProblem(dynamics, u0, (tmin, tmax_problem))
+
+    # Callbacks periodically increase the input to the integrators:
+    Δt1 = 0.5
+    increase_du_1 = integrator -> du[1] += 1
+    periodic1 = PeriodicCallback(increase_du_1, Δt1)
+
+    Δt2 = 1.
+    increase_du_2 = integrator -> du[2] += 1
+    periodic2 = PeriodicCallback(increase_du_2, Δt2)
+
+    # Terminate at tmax (regardless of whether the tspan of the ODE problem is infinite).
+    terminator = DiscreteCallback((t, u, integrator) -> t == tmax, terminate!)
+
+    # Solve.
+    sol = solve(prob, Tsit5(); callback = CallbackSet(terminator, periodic1, periodic2), tstops = [tmax])
+
+    # Make sure we haven't integrated past tmax:
+    @test sol.t[end] == tmax
+
+    # Make sure that the components of du have been incremented the appropriate number of times.
+    Δts = [Δt1, Δt2]
+    expected_num_calls = map(Δts) do Δt
+        floor(Int, (tmax - tmin) / Δt) + 1
+    end
+    @test du == expected_num_calls
+
+    # Make sure that the final state matches manual integration of the piecewise linear function
+    foreach(Δts, sol.u[end], du) do Δt, u_i, du_i
+        @test u_i ≈ Δt * sum(1 : du_i - 1) + rem(tmax - tmin, Δt) * du_i atol = 1e-5
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,4 +8,5 @@ tic()
 @time @testset "Manifold tests" begin include("manifold_tests.jl") end
 @time @testset "StepsizeLimiter tests" begin include("stepsizelimiter_tests.jl") end
 @time @testset "Saving tests" begin include("saving_tests.jl") end
+@time @testset "Periodic tests" begin include("periodic_tests.jl") end
 toc()


### PR DESCRIPTION
This is to support stuff like https://github.com/tkoolen/RigidBodySim.jl/issues/5.

I'm aware of http://docs.juliadiffeq.org/latest/features/diffeq_arrays.html#Example:-A-Control-Problem-1, but I wasn't satisfied with simply using the `tstops` kwarg to `solve`. Reasons:
1. I want support for infinite `tspan`s (where integration continues indefinitely until some callback `terminate!`s the integrator, in my case a stop button in a GUI)
2. Even for finite `tspan`s you'd end up with a length of the internal `tstops` collection that is linear in the length of the integration time interval with the other method; that's not the end of the world, but it seems unnecessary.
3. With `PeriodicCallback`s, you only have to pass the callback into `solve` or `init`. I think this is cleaner than having to pass in both a callback and `tstops`, especially if there are multiple callbacks that each have a different period.