### PR TITLE
Import NLSOLVEJL_SETUP from OrdinaryDiffEq

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,6 @@
 julia 0.6.0
 DiffEqBase 0.6.0
-NLsolve
-ForwardDiff 0.5 0.6-
-DiffBase
-OrdinaryDiffEq
+OrdinaryDiffEq 2.21.3
 RecursiveArrayTools
 DataStructures
 RecipesBase

--- a/src/DiffEqCallbacks.jl
+++ b/src/DiffEqCallbacks.jl
@@ -2,10 +2,10 @@ __precompile__()
 
 module DiffEqCallbacks
 
-  using DiffEqBase, NLsolve, ForwardDiff, RecursiveArrayTools, DataStructures, RecipesBase
+  using DiffEqBase, RecursiveArrayTools, DataStructures, RecipesBase
 
   import OrdinaryDiffEq: fix_dt_at_bounds!, modify_dt_for_tstops!, ode_addsteps!,
-                         ode_interpolant, non_autodiff_setup
+                         ode_interpolant, NLSOLVEJL_SETUP
 
   include("autoabstol.jl")
   include("manifold.jl")


### PR DESCRIPTION
Removes redundant definition of `NLSOLVEJL_SETUP`. Supersedes https://github.com/JuliaDiffEq/DiffEqCallbacks.jl/pull/17 and depends on unreleased version 2.21.3 of OrdinaryDiffEq.