### PR TITLE
Add TerminateSteadyState callback

### DIFF
--- a/src/DiffEqCallbacks.jl
+++ b/src/DiffEqCallbacks.jl
@@ -14,5 +14,6 @@ module DiffEqCallbacks
   include("function_caller.jl")
   include("saving.jl")
   include("iterative_and_periodic.jl")
+  include("terminatesteadystate.jl")
 
 end # module

--- a/src/terminatesteadystate.jl
+++ b/src/terminatesteadystate.jl
@@ -1,18 +1,20 @@
 
 # Default test function
-# Terminate when all derivatives fall below a threshold, with early exit
-function allDerivPass(derivs, tol)
-    for der in derivs
-        der > tol && (return false)
-    end
+# Terminate when all derivatives fall below a threshold or
+#   when derivatives are small than a fraction of state
+function allDerivPass(integrator, t, abstol, reltol)
+    du = integrator(t, Val{1})
+    any(du .> abstol) &&  (return false)
+    u = integrator(t)
+    any(du .> reltol.*u) &&  (return false)
     return true
 end
 
 # Allow user-defined tolerances and test functions but use sensible defaults
-# test function must take derivatives as first argument, tolerance as second,
-#   return true/false
-function TerminateSteadyState(tol = 1e-8, test = allDerivPass)
-    condition = (u, t, integrator) -> test(integrator(t, Val{1}), tol)
+# test function must take integrator, time, followed by absolute
+#   and relative tolerance and return true/false
+function TerminateSteadyState(abstol = 1e-8, reltol = 1e-6, test = allDerivPass)
+    condition = (u, t, integrator) -> test(integrator, t, abstol, reltol)
     affect! = (integrator) -> terminate!(integrator)
     DiscreteCallback(condition, affect!)
 end

--- a/src/terminatesteadystate.jl
+++ b/src/terminatesteadystate.jl
@@ -1,0 +1,20 @@
+
+# Default test function
+# Terminate when all derivatives fall below a threshold, with early exit
+function allDerivPass(derivs, tol)
+    for der in derivs
+        der > tol && (return false)
+    end
+    return true
+end
+
+# Allow user-defined tolerances and test functions but use sensible defaults
+# test function must take derivatives as first argument, tolerance as second,
+#   return true/false
+function TerminateSteadyState(tol = 1e-8, test = allDerivPass)
+    condition = (u, t, integrator) -> test(integrator(t, Val{1}), tol)
+    affect! = (integrator) -> terminate!(integrator)
+    DiscreteCallback(condition, affect!)
+end
+
+export TerminateSteadyState

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Base.Test
 tic()
 @time @testset "AutoAbstol" begin include("autoabstol_tests.jl") end
 @time @testset "Domain tests" begin include("domain_tests.jl") end
+@time @testset "TerminateSteadyState tests" begin include("terminatesteadystate_test.jl") end
 @time @testset "Manifold tests" begin include("manifold_tests.jl") end
 @time @testset "StepsizeLimiter tests" begin include("stepsizelimiter_tests.jl") end
 @time @testset "Function Calling tests" begin include("funccall_tests.jl") end

--- a/test/terminatesteadystate_test.jl
+++ b/test/terminatesteadystate_test.jl
@@ -1,0 +1,10 @@
+using OrdinaryDiffEq, Base.Test, DiffEqBase, DiffEqCallbacks
+
+model(u,t,p) = -0.1.*u
+u0 = [1.0, 10.0]
+tspan = (0.0, 300.0)
+prob = ODEProblem(model, u0, tspan)
+sim = solve(prob, Tsit5(), callback=TerminateSteadyState())
+
+@test all(sim(sim.t[end],Val{1}) .< 1e-8)
+@test sim.t[end] < tspan[2]


### PR DESCRIPTION
Simple Discrete Callback that terminates the simulation when it is close to the steady-state. By default, the termination condition is that the absolute values of all derivatives fall below a tolerance. Users can pass their own tolerance and test function to specify other termination conditions (e.g. use different tolerances per state variable).