### PR TITLE
Improvements to `allDerivPass`

### DIFF
--- a/src/terminatesteadystate.jl
+++ b/src/terminatesteadystate.jl
@@ -1,12 +1,21 @@
 
+# Check if a cache for du can be used inside allDerivPass
+Base.@pure usecache(z) = true
+Base.@pure usecache(z::Number) = false
+Base.@pure usecache(z::StaticArrays.SArray) = false
+
 # Default test function
 # Terminate when all derivatives fall below a threshold or
-#   when derivatives are small than a fraction of state
-function allDerivPass(integrator, t, abstol, reltol)
-    du = integrator(t, Val{1})
-    any(du .> abstol) &&  (return false)
-    u = integrator(t)
-    any(du .> reltol.*u) &&  (return false)
+#   when derivatives are smaller than a fraction of state
+function allDerivPass(integrator, abstol, reltol)
+    if usecache(integrator.u)
+        du = first(get_tmp_cache(integrator))
+        DiffEqBase.get_du!(du, integrator)
+    else
+        du = get_du(integrator)
+    end
+    any(abs(d) > abstol && abs(d) > reltol*abs(u) for (d,abstol, reltol, u) =
+           zip(du, cycle(abstol), cycle(reltol), integrator.u)) && (return false)
     return true
 end
 
@@ -14,7 +23,7 @@ end
 # test function must take integrator, time, followed by absolute
 #   and relative tolerance and return true/false
 function TerminateSteadyState(abstol = 1e-8, reltol = 1e-6, test = allDerivPass)
-    condition = (u, t, integrator) -> test(integrator, t, abstol, reltol)
+    condition = (u, t, integrator) -> test(integrator, abstol, reltol)
     affect! = (integrator) -> terminate!(integrator)
     DiscreteCallback(condition, affect!)
 end

--- a/test/terminatesteadystate_test.jl
+++ b/test/terminatesteadystate_test.jl
@@ -1,9 +1,20 @@
-using OrdinaryDiffEq, Base.Test, DiffEqBase, DiffEqCallbacks
+using OrdinaryDiffEq, Base.Test, DiffEqBase, DiffEqCallbacks, StaticArrays
 
-model(u,t,p) = -0.1.*u
+# In-place modification of du (as array)
+model(du,u,t,p) = du .= -0.1.*u
 u0 = [1.0, 10.0]
-tspan = (0.0, 300.0)
+tspan = (0.0, 1000.0)
 prob = ODEProblem(model, u0, tspan)
+sim = solve(prob, Tsit5(), callback=TerminateSteadyState())
+
+@test all(sim(sim.t[end],Val{1}) .< 1e-8)
+@test sim.t[end] < tspan[2]
+
+# Out-of-place modification of du (as array)
+smodel(u,t,p) = -0.1.*u
+su0 = @SVector [1.0, 10.0]
+tspan = (0.0, 1000.0)
+prob = ODEProblem(smodel, su0, tspan)
 sim = solve(prob, Tsit5(), callback=TerminateSteadyState())
 
 @test all(sim(sim.t[end],Val{1}) .< 1e-8)


### PR DESCRIPTION
Use cache for `du` when possible (i.e. exclude Number and SArray).
Use iterator inside `any` with cycling zip
Fuse both conditions (abstol, reltol) such that only one needs to be met per derivative (important for states that convergence to 0)
Update tests  and new test for in-place model
There no need to pass `t` to test function as both `u` and `du` can be extracted directly (documentation should be updated)