### PR TITLE
error in initialize function in PeriodicCallback

### DIFF
--- a/src/iterative_and_periodic.jl
+++ b/src/iterative_and_periodic.jl
@@ -67,7 +67,7 @@ function PeriodicCallback(f, Δt::Number; initialize = DiffEqBase.INITIALIZE_DEF
             tnext[] = t
             affect!(integrator)
         else
-            tnext[] = time_choice(integrator)
+            tnext[] = t + Δt
             add_tstop!(integrator, tnext[])
         end
     end


### PR DESCRIPTION
it appears that the `initialize_periodic` function was copy-pasted from the above `initialize_iterative` function in the `IterativeCallback` constructor, and the `time_choice(integrator)` call was left inside `initialize_periodic`; I have changed it to `t + Δt`.