### PR TITLE
ManifoldProjection for ManifoldProjections.jl Manifolds

### DIFF
--- a/src/manifold.jl
+++ b/src/manifold.jl
@@ -1,3 +1,6 @@
+# TODO is this necessary and should it be added to REQUIRE?
+using ManifoldProjections
+
 # wrapper for non-autonomous functions
 mutable struct NonAutonomousFunction{F,autonomous}
   f::F
@@ -50,6 +53,14 @@ function ManifoldProjection(g; nlsolve=NLSOLVEJL_SETUP(), save=true,
   DiscreteCallback(condtion, affect!;
                    initialize = Manifold_initialize,
                    save_positions=save_positions)
+end
+
+function ManifoldProjection(M::Mfd; save=true) where {Mfd <: Manifold}
+    affect!(integrator) = retract!(M, integrator.u)
+    condition = (u, t, integrator) -> true
+    save_positions = (false,save)
+    DiscreteCallback(condition, affect!,
+                     save_positions=save_positions)
 end
 
 export ManifoldProjection


### PR DESCRIPTION
Hi, I added a ManifoldProjection for Manifolds using the new module of NLSolvers.
Two questions, is it possible not to use ManifoldProjections as the function is in any case only helpful when the user somewhere loaded the module himself?
And I do not get the autonomous function stuff in the original ManifoldProjection functions, has this any relevance here?
If it is fine like this I would then write a simple example for the documentation.
Lastly I am not sure whether you want to wait with including this until ManifoldProjections is available in Pkg directly.