### PR TITLE
Remove excessive saving in TerminateSteadyState.

### DIFF
--- a/src/terminatesteadystate.jl
+++ b/src/terminatesteadystate.jl
@@ -19,7 +19,7 @@ end
 function TerminateSteadyState(abstol = 1e-8, reltol = 1e-6, test = allDerivPass)
     condition = (u, t, integrator) -> test(integrator, abstol, reltol)
     affect! = (integrator) -> terminate!(integrator)
-    DiscreteCallback(condition, affect!)
+    DiscreteCallback(condition, affect!; save_positions = (true, false))
 end
 
 export TerminateSteadyState


### PR DESCRIPTION
Ensure that TerminateSteadyState only saves the last timepoint once.

This is not a very big deal, but the double saving caused an issue for me and I felt that this behaviour would be more natural. 